### PR TITLE
fix: normalize audio before int16 conversion for MP3 output to prevent crackling

### DIFF
--- a/inference/msst_infer.py
+++ b/inference/msst_infer.py
@@ -342,6 +342,9 @@ class MSSeparator:
 			file = os.path.join(store_dir, file_name + ".mp3")
 
 			if audio.dtype != np.int16:
+				peak = np.max(np.abs(audio))
+				if peak > 1.0:
+					audio = audio / peak
 				audio = (audio * 32767).astype(np.int16)
 
 			audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)

--- a/inference/preset_infer.py
+++ b/inference/preset_infer.py
@@ -268,6 +268,9 @@ def save_audio(audio, sr, output_format, file_name, store_dir):
 	elif output_format.lower() == "mp3":
 		file = os.path.join(store_dir, file_name + ".mp3")
 		if audio.dtype != np.int16:
+			peak = np.max(np.abs(audio))
+			if peak > 1.0:
+				audio = audio / peak
 			audio = (audio * 32767).astype(np.int16)
 		audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)
 		audio_segment.export(file, format="mp3", bitrate=mp3_bit_rate)

--- a/inference/vr_infer.py
+++ b/inference/vr_infer.py
@@ -253,6 +253,9 @@ class VRSeparator:
 			file = os.path.join(store_dir, file_name + ".mp3")
 
 			if audio.dtype != np.int16:
+				peak = np.max(np.abs(audio))
+				if peak > 1.0:
+					audio = audio / peak
 				audio = (audio * 32767).astype(np.int16)
 
 			audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)


### PR DESCRIPTION
## Problem

When output format is set to MP3, the separated accompaniment often contains
crackling/popping artifacts. This does not occur when outputting WAV first
and then converting to MP3 externally.

## Root Cause

The `save_audio()` method in three files directly converts float audio to int16:
```python
audio = (audio * 32767).astype(np.int16)
```

Source separation outputs frequently have peaks exceeding [-1.0, 1.0] (> 0dBFS).
Multiplying by 32767 and casting to int16 hard-clips these peaks, causing
audible harmonic distortion.

The WAV path uses 32-bit float (`subtype='FLOAT'`), preserving the full
dynamic range without clipping, which is why WAV to external MP3 conversion
sounds clean.

## Fix

Added peak normalization before int16 conversion in all three `save_audio()`
implementations:

1. `inference/msst_infer.py`
2. `inference/vr_infer.py`
3. `inference/preset_infer.py`

For each, before `audio = (audio * 32767).astype(np.int16)`, we now check:
```python
peak = np.max(np.abs(audio))
if peak > 1.0:
    audio = audio / peak
```

This ensures no hard clipping occurs during the float-to-int16 conversion.

## Verification

- Select MP3 output format and run separation on a track with high dynamic range
- The output should no longer contain crackling/popping artifacts
- The result should match the quality of WAV output converted to MP3 externally