### PR TITLE
fix: pipe float32 audio directly to FFmpeg for MP3 encoding to prevent crackling

### DIFF
--- a/inference/msst_infer.py
+++ b/inference/msst_infer.py
@@ -9,7 +9,7 @@ import platform
 import subprocess
 from time import time
 from tqdm import tqdm
-from pydub import AudioSegment
+from utils.constant import FFMPEG
 
 from safetensors.torch import load_file
 
@@ -340,16 +340,18 @@ class MSSeparator:
 
 		elif self.output_format.lower() == "mp3":
 			file = os.path.join(store_dir, file_name + ".mp3")
+			channels = audio.shape[1] if audio.ndim > 1 else 1
+			subprocess.run(
+				[FFMPEG, "-y", "-f", "f32le",
+				 "-ar", str(sr),
+				 "-ac", str(channels),
+				 "-i", "pipe:0",
+				 "-codec:a", "libmp3lame",
+				 "-b:a", self.audio_params["mp3_bit_rate"],
+				 file],
+				input=audio.astype(np.float32).tobytes(), check=True, capture_output=True
+			)
 
-			if audio.dtype != np.int16:
-				peak = np.max(np.abs(audio))
-				if peak > 1.0:
-					audio = audio / peak
-				audio = (audio * 32767).astype(np.int16)
-
-			audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)
-
-			audio_segment.export(file, format="mp3", bitrate=self.audio_params["mp3_bit_rate"])
 
 		else:
 			file = os.path.join(store_dir, file_name + ".wav")

--- a/inference/msst_infer.py
+++ b/inference/msst_infer.py
@@ -342,6 +342,9 @@ class MSSeparator:
 			file = os.path.join(store_dir, file_name + ".mp3")
 
 			if audio.dtype != np.int16:
+				peak = np.max(np.abs(audio))
+				if peak > 1.0:
+					audio = audio / peak
 				audio = (audio * 32767).astype(np.int16)
 
 			audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)

--- a/inference/preset_infer.py
+++ b/inference/preset_infer.py
@@ -268,6 +268,9 @@ def save_audio(audio, sr, output_format, file_name, store_dir):
 	elif output_format.lower() == "mp3":
 		file = os.path.join(store_dir, file_name + ".mp3")
 		if audio.dtype != np.int16:
+			peak = np.max(np.abs(audio))
+			if peak > 1.0:
+				audio = audio / peak
 			audio = (audio * 32767).astype(np.int16)
 		audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)
 		audio_segment.export(file, format="mp3", bitrate=mp3_bit_rate)

--- a/inference/preset_infer.py
+++ b/inference/preset_infer.py
@@ -5,7 +5,7 @@ import soundfile as sf
 import librosa
 import glob
 import traceback
-from pydub import AudioSegment
+import subprocess
 
 from utils.logger import get_logger
 from utils.constant import *
@@ -267,13 +267,17 @@ def save_audio(audio, sr, output_format, file_name, store_dir):
 		sf.write(file, audio, sr, subtype=flac_bit_depth)
 	elif output_format.lower() == "mp3":
 		file = os.path.join(store_dir, file_name + ".mp3")
-		if audio.dtype != np.int16:
-			peak = np.max(np.abs(audio))
-			if peak > 1.0:
-				audio = audio / peak
-			audio = (audio * 32767).astype(np.int16)
-		audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)
-		audio_segment.export(file, format="mp3", bitrate=mp3_bit_rate)
+		channels = audio.shape[1] if audio.ndim > 1 else 1
+		subprocess.run(
+			[FFMPEG, "-y", "-f", "f32le",
+			 "-ar", str(sr),
+			 "-ac", str(channels),
+			 "-i", "pipe:0",
+			 "-codec:a", "libmp3lame",
+			 "-b:a", mp3_bit_rate,
+			 file],
+			input=audio.astype(np.float32).tobytes(), check=True, capture_output=True
+		)
 	else:
 		file = os.path.join(store_dir, file_name + ".wav")
 		sf.write(file, audio, sr, subtype=wav_bit_depth)

--- a/inference/vr_infer.py
+++ b/inference/vr_infer.py
@@ -253,6 +253,9 @@ class VRSeparator:
 			file = os.path.join(store_dir, file_name + ".mp3")
 
 			if audio.dtype != np.int16:
+				peak = np.max(np.abs(audio))
+				if peak > 1.0:
+					audio = audio / peak
 				audio = (audio * 32767).astype(np.int16)
 
 			audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)

--- a/inference/vr_infer.py
+++ b/inference/vr_infer.py
@@ -11,11 +11,10 @@ import torch
 import librosa
 import numpy as np
 import soundfile as sf
-from pydub import AudioSegment
 from tqdm import tqdm
 from modules.vocal_remover.vr_separator import VRSeparator as VR
 from utils.logger import get_logger, set_log_level
-from utils.constant import TEMP_PATH, MODELS_INFO
+from utils.constant import TEMP_PATH, MODELS_INFO, FFMPEG
 
 
 class VRSeparator:
@@ -251,16 +250,17 @@ class VRSeparator:
 
 		elif self.output_format.lower() == "mp3":
 			file = os.path.join(store_dir, file_name + ".mp3")
-
-			if audio.dtype != np.int16:
-				peak = np.max(np.abs(audio))
-				if peak > 1.0:
-					audio = audio / peak
-				audio = (audio * 32767).astype(np.int16)
-
-			audio_segment = AudioSegment(audio.tobytes(), frame_rate=sr, sample_width=audio.dtype.itemsize, channels=2)
-
-			audio_segment.export(file, format="mp3", bitrate=self.audio_params["mp3_bit_rate"])
+			channels = audio.shape[1] if audio.ndim > 1 else 1
+			subprocess.run(
+				[FFMPEG, "-y", "-f", "f32le",
+				 "-ar", str(sr),
+				 "-ac", str(channels),
+				 "-i", "pipe:0",
+				 "-codec:a", "libmp3lame",
+				 "-b:a", self.audio_params["mp3_bit_rate"],
+				 file],
+				input=audio.astype(np.float32).tobytes(), check=True, capture_output=True
+			)
 
 		else:
 			file = os.path.join(store_dir, file_name + ".wav")


### PR DESCRIPTION
## Problem

The previous fix (#112) added peak normalization before int16 conversion
to prevent hard clipping. However, normalization reduces overall volume
to avoid clipping peaks, resulting in quieter output compared to the
WAV-to-MP3 workflow in professional audio tools.

## Root Cause

The source of the crackling was the manual float-to-int16 conversion:
```python
audio = (audio * 32767).astype(np.int16)
```
Source separation outputs frequently have peaks exceeding [-1.0, 1.0],
and this hard clip produces audible harmonic distortion.

## Improved Fix

Instead of manual int16 conversion via pydub, pipe raw float32 PCM data
directly to FFmpeg/libmp3lame through stdin. libmp3lame handles the
float-to-int quantization internally with proper noise shaping, exactly
as professional audio tools do.

Key changes per file:
- Remove `from pydub import AudioSegment`
- Add `FFMPEG` import from `utils.constant`
- Replace int16 conversion + pydub export with FFmpeg stdin pipe

Benefits over the previous normalization approach:
- No volume loss (no peak normalization needed)
- No temp files (data flows through memory)
- Matches WAV-to-MP3 quality in Adobe Audition
- Uses the project's existing bundled/system FFmpeg

## Files Changed
- `inference/msst_infer.py`
- `inference/vr_infer.py`
- `inference/preset_infer.py`